### PR TITLE
Fix toast auto-dismiss timing

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -9,7 +9,11 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Amount of time (in ms) a toast stays visible before being removed
+// The previous value left toasts on screen for an excessively long
+// period (over 16 minutes) which meant notifications lingered and
+// cluttered the UI. Five seconds is a more typical default.
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,11 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Amount of time (in ms) a toast stays visible before being removed
+// The previous value left toasts on screen for over 16 minutes which
+// caused them to pile up and never disappear during normal use.
+// Five seconds is a much more reasonable default.
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten toast removal delay so notifications disappear after ~5s

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4ed1c244832faa4dd8a951ce3a4a